### PR TITLE
Implement simple Vue calculator with history

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,33 @@
+const { createApp, ref } = Vue;
+
+createApp({
+  setup() {
+    const display = ref('');
+    const history = ref([]);
+    let idCounter = 0;
+
+    const append = (val) => {
+      display.value += val.toString();
+    };
+
+    const clearDisplay = () => {
+      display.value = '';
+    };
+
+    const calculate = () => {
+      try {
+        const result = Function('return ' + display.value)();
+        history.value.unshift({
+          id: idCounter++,
+          expression: display.value,
+          result,
+        });
+        display.value = result.toString();
+      } catch (e) {
+        display.value = 'Error';
+      }
+    };
+
+    return { display, history, append, clearDisplay, calculate };
+  },
+}).mount('#app');

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vue Calculator</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-5 font-sans">
+  <div id="app" class="max-w-sm mx-auto">
+    <input
+      class="w-full h-10 text-xl text-right mb-2 p-2 border rounded"
+      type="text"
+      v-model="display"
+      readonly
+    />
+    <div class="grid grid-cols-4 gap-2">
+      <button class="py-2 text-lg bg-gray-200 rounded" v-for="n in [7,8,9]" @click="append(n)">{{ n }}</button>
+      <button class="py-2 text-lg bg-gray-200 rounded" @click="append('/')">/</button>
+      <button class="py-2 text-lg bg-gray-200 rounded" v-for="n in [4,5,6]" @click="append(n)">{{ n }}</button>
+      <button class="py-2 text-lg bg-gray-200 rounded" @click="append('*')">*</button>
+      <button class="py-2 text-lg bg-gray-200 rounded" v-for="n in [1,2,3]" @click="append(n)">{{ n }}</button>
+      <button class="py-2 text-lg bg-gray-200 rounded" @click="append('-')">-</button>
+      <button class="py-2 text-lg bg-gray-200 rounded" @click="append(0)">0</button>
+      <button class="py-2 text-lg bg-gray-200 rounded" @click="append('.')">.</button>
+      <button class="py-2 text-lg bg-blue-400 text-white rounded" @click="calculate">=</button>
+      <button class="py-2 text-lg bg-gray-200 rounded" @click="append('+')">+</button>
+      <button class="py-2 text-lg bg-red-400 text-white rounded col-span-4" @click="clearDisplay">C</button>
+    </div>
+    <div class="mt-4 space-y-1">
+      <div class="text-sm" v-for="item in history" :key="item.id">
+        {{ item.expression }} = {{ item.result }}
+      </div>
+    </div>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with a calculator built on Vue Composition API
- calculator allows entering expressions and shows a history of past calculations
- refactor to separate `app.js` and integrate TailwindCSS

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684215bcf94c832989999111070e782f